### PR TITLE
refactor: update data structures for Skripsi and enhance item handling

### DIFF
--- a/src/app/api/chatbot/route.ts
+++ b/src/app/api/chatbot/route.ts
@@ -179,7 +179,6 @@ export async function POST(request: Request) {
    type Buku =  {
     id: string;
     judul: string;
-    abstrak?: string;
     jumlah: number;
     tersedia: number;
     dipinjam: number;
@@ -226,26 +225,35 @@ export async function POST(request: Request) {
     tahun: string;
   }
 , dan
-    type Skripsi = {
-    id: string;
-    judul: string;
-    abstrak?: string;
-    count?: number;
-    nim: string;
-    tahun: string;
-    updatedAt?: string;
-    createdAt?: string;
-    mahasiswa: Mahasiswa;
-}
-    type Mahasiswa = {
-    id: string;
-    name: string;
-    masuk: string;
-    lulus: string;
-    ipk: string;
-    fakultas?: string;
-    program_studi?: string;
-  }
+
+type Skripsi = {
+  id: string;
+  judul: string;
+  abstrak: string;
+  jumlah: number;
+  tersedia: number;
+  dipinjam: number;
+  tahun: string;
+  nim: string;
+  createdAt: string; // ISO date string
+  updatedAt: string; // ISO date string
+  count: number;
+  fakultas: string;
+  nama_mahasiswa: string;
+  program_studi: string;
+  link: string;
+  mahasiswa?: Mahasiswa;
+};
+
+export type Mahasiswa = {
+  id: string;
+  name: string;
+  masuk: string;
+  lulus: string;
+  ipk: string;
+  fakultas?: string;
+  program_studi?: string;
+};
 
       **TIDAK AKAN MENCARI DI INTERNET**.
       **JIKA DATA YANG DIMINTA TIDAK ADA, MAKA JANGAN CARI DATA DILUAR DATABASE LOKAL, 

--- a/src/components/ChatbotSection.tsx
+++ b/src/components/ChatbotSection.tsx
@@ -14,11 +14,11 @@ const ChatbotSection: React.FC = () => {
       Selamat datang di Perpustakaan USD! 👋
       <ul>
         <li>Saya siap membantu Anda mencari buku dan koleksi perpustakaan. Berikut beberapa contoh yang bisa Anda tanyakan:</li>
-        <li>"Rekomendasikan skripsi tentang pendidikan, dong!"</li>
-        <li>"Rekomendasikan saya buku tentang habits"</li>
-        <li>"Apakah buku "Sapiens: A Brief History of Humankind" masih tersedia untuk dipinjam?"</li>
+        <li>"Rekomendasikan skripsi tentang teknik, dong!"</li>
+        <li>"Rekomendasikan saya buku tentang psikologi"</li>
+        <li>"Apakah buku "Bayesian Reasoning and Machine Learning" masih tersedia untuk dipinjam?"</li>
         <li>"Rekomendasikan saya jurnal terkait teknik"</li>
-        <li>"Dimana letak buku Bumi Manusia?"</li>
+        <li>"Dimana letak buku The Strength in Our Scars?"</li>
       </ul>
       Silakan ketik pertanyaan Anda!`,
       timestamp: new Date().toLocaleTimeString([], {

--- a/src/components/library/LibraryItemBubbleChat.tsx
+++ b/src/components/library/LibraryItemBubbleChat.tsx
@@ -1,26 +1,32 @@
 import { LibraryBubbleItemType, Publikasi } from "@/libs/types";
 import { Book, Journal, LibraryItem, Skripsi } from "@/libs/types/libraryType";
+import { useEffect } from "react";
 
 const LibraryItemBubbleChat: React.FC<{
   item: LibraryItem | Publikasi;
   type: LibraryBubbleItemType | undefined;
 }> = ({ item, type }) => {
+  console.log({ item, type });
+
   return (
     <>
       {type === "buku" &&
-        (item as Book)?.hasOwnProperty("sinopsis") === true && (
+        ((item as Book)?.hasOwnProperty("penerbit") === true ||
+          (item as Book)?.hasOwnProperty("pengarang") === true) && (
           <BookItemBubbleChat item={item as Book} />
         )}
 
       {type === "jurnal" &&
-        (item as Journal)?.hasOwnProperty("publikasi") === true && (
+        ((item as Journal)?.hasOwnProperty("publikasi") === true ||
+          (item as Journal)?.hasOwnProperty("jurnal_id") === true) && (
           <JournalItemBubbleChat item={item as Journal} />
         )}
 
-      {type === "skripsi" &&
-        (item as Skripsi)?.hasOwnProperty("mahasiswa") === true && (
-          <SkripsiItemBubbleChat item={item as Skripsi} />
-        )}
+      {((type === "skripsi" &&
+        (item as Skripsi)?.hasOwnProperty("mahasiswa") === true) ||
+        (item as Skripsi).hasOwnProperty("nama_mahasiswa") === true) && (
+        <SkripsiItemBubbleChat item={item as Skripsi} />
+      )}
       {type === "publikasi" &&
         (item as Publikasi)?.hasOwnProperty("volume") === true && (
           <PublicationItemBubbleChat item={item as Publikasi} />
@@ -55,7 +61,12 @@ const SkripsiItemBubbleChat: React.FC<{
         <span className="font-bold">{(item as Skripsi)?.judul || ""}</span>{" "}
       </h3>
       <p>Sinopsis: {(item as Skripsi)?.abstrak || ""}</p>
-      <p>Nama Mahasiswa: {(item as Skripsi)?.mahasiswa?.name || ""} </p>
+      <p>
+        Nama Mahasiswa:{" "}
+        {(item as Skripsi)?.mahasiswa?.name ||
+          (item as Skripsi)?.nama_mahasiswa ||
+          ""}{" "}
+      </p>
       <p>Tahun Skripsi: {(item as Skripsi)?.tahun || ""}</p>
     </div>
   );

--- a/src/libs/types/libraryType.ts
+++ b/src/libs/types/libraryType.ts
@@ -31,7 +31,6 @@ export interface Journal extends BaseItem {
   type: "journal";
   publikasi?: Publikasi;
 }
-
 export interface Skripsi extends BaseItem {
   tahun: string;
   nim: string;
@@ -41,9 +40,6 @@ export interface Skripsi extends BaseItem {
   fakultas?: string;
   program_studi?: string;
   mahasiswa?: Mahasiswa;
-  // jumlah?: number;
-  // tersedia?: number;
-  // dipinjam?: number;
 }
 
 export type LibraryItem = Book | Journal | Skripsi;


### PR DESCRIPTION
This pull request introduces several updates to the data models and UI logic for library items, especially focusing on the `Skripsi` (thesis) type. The changes improve type consistency, enhance the chatbot's sample prompts, and make the UI more robust in handling different data shapes for library items.

### Data Model Updates

* The `Skripsi` type in `src/app/api/chatbot/route.ts` is expanded to include more fields such as `jumlah`, `tersedia`, `dipinjam`, `createdAt`, `updatedAt`, `count`, `fakultas`, `nama_mahasiswa`, `program_studi`, and `link`, and now requires `abstrak` (abstract) to be present. The optional `Mahasiswa` type is also updated and exported.
* The `Buku` type removes the optional `abstrak` field for better consistency.
* Unused or commented-out fields in the `Skripsi` interface in `src/libs/types/libraryType.ts` are cleaned up for clarity.

### UI Logic Improvements

* The logic for rendering library items in `LibraryItemBubbleChat.tsx` is made more robust: checks for additional properties (like `nama_mahasiswa` for `Skripsi`, and `penerbit`/`pengarang` for `Book`) to decide which bubble chat component to render, improving compatibility with varied data shapes.
* The `SkripsiItemBubbleChat` component now displays the student's name using either the nested `mahasiswa.name` or the top-level `nama_mahasiswa` field, ensuring the name is shown regardless of the data structure.

### Chatbot Prompt Updates

* Chatbot sample prompts in `ChatbotSection.tsx` are updated to use more relevant book and thesis examples, making the chatbot guidance clearer and more domain-appropriate.

These changes collectively make the data structures more consistent, improve UI resilience to data variations, and provide better sample prompts for users interacting with the chatbot.